### PR TITLE
libxml++3 uses a different name for TextReader::xmlNodeType

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ main.o: main.c
 	gcc -Wall -fPIC -std=c11 -D_GNU_SOURCE main.c -c `pkg-config --cflags gtkmm-2.4`
 install:
 	cp *.so /usr/lib/deadbeef/
-	msgfmt po/ru/deadbeef-lyricbar.po -o /usr/share/locale/ru/LC_MESSAGES/deadbeef-lyricbar.mo
+	msgfmt gettext/ru/deadbeef-lyricbar.po -o /usr/share/locale/ru/LC_MESSAGES/deadbeef-lyricbar.mo
 clean:
 	rm -f *.o *.so

--- a/utils.cpp
+++ b/utils.cpp
@@ -95,7 +95,7 @@ experimental::optional<string> get_lyrics_from_lyricwiki(DB_playItem_t *track) {
         xmlpp::TextReader reader(api_url);
 
         while (reader.read()) {
-            if (reader.get_node_type() == xmlpp::TextReader::xmlNodeType::Element
+            if (reader.get_node_type() == xmlpp::TextReader::NodeType::Element
                     && reader.get_name() == "lyrics") {
                 reader.read();
                 // got the cropped version of lyrics — display it before the complete one is got


### PR DESCRIPTION
The latest changes introduced with the migration off of cmake to a simple Makefile seem to imply the desire to use the newest version of libxml++. However, the code was not adjusted to reflect this therefore causing compilation failures. This corrects it. If you prefer to stick to the older libxml++, please correct the `pkg-config` to use the old includes instead.

The second commit is unrelated: `po` files seem to have been moved around.

I also have a diff to README in the works, I plan to send it in a separate pull request along with any additional changes to the Makefile once I get the plugin to actually work against the current deadbeef master :)