### PR TITLE
Fix readme deadbeef sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ To use this plugin, you need to have [gtkmm](http://www.gtkmm.org/) and [libxml+
 
 While gtkmm is available in the repositories of most modern distributions (e.g. in Ubuntu you'll have to install `libgtkmm-3.0-dev` for the gtk3 version of lyricbar), libxml++3 is absent in many of them. If that's the case, you'll have to build it from sources (e.g. for Ubuntu: `sudo apt install checkinstall libxml2-dev && wget http://ftp.gnome.org/pub/GNOME/sources/libxml++/3.0/libxml++-3.0.1.tar.xz && tar -xJf libxml++-3.0.1.tar.xz && cd libxml++-3.0.1 && ./configure --prefix=/usr && make && sudo checkinstall`).
 
+You need deadbeef.h file to build this plugin. The file /usr/include/deadbeef/deadbeef.h should've been installed with the player itself. If not -- look for deadbeef-plugin-dev package, or something like this. Or get the file from a source tarball.
+
 ## Installation
 Clone this repository and perform the following:
 ```sh

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -110,6 +110,9 @@ GtkWidget *construct_lyricbar() {
 	lyricView->set_can_focus(false);
 	lyricView->set_justification(get_justification());
 	lyricView->set_wrap_mode(WRAP_WORD_CHAR);
+        if (get_justification() == JUSTIFY_LEFT) {
+           lyricView->set_left_margin(20);
+        }
 	lyricView->show();
 
 	lyricbar = new ScrolledWindow();


### PR DESCRIPTION
Added deadbeef-plugin-dev in readme. Without deadbeef.h plugin will fail to compile.