### PR TITLE
Add Ogg Vorbis version of "unsynced lyrics" tag

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -91,6 +91,7 @@ experimental::optional<ustring> get_lyrics_from_metadata(DB_playItem_t *track) {
 	pl_lock_guard guard;
 	const char *lyrics = deadbeef->pl_find_meta(track, "lyrics")
 	                  ?: deadbeef->pl_find_meta(track, "unsynced lyrics");
+	                  ?: deadbeef->pl_find_meta(track, "UNSYNCEDLYRICS");
 	if (lyrics)
 		return ustring{lyrics};
 	else return {};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -90,7 +90,7 @@ static
 experimental::optional<ustring> get_lyrics_from_metadata(DB_playItem_t *track) {
 	pl_lock_guard guard;
 	const char *lyrics = deadbeef->pl_find_meta(track, "lyrics")
-	                  ?: deadbeef->pl_find_meta(track, "unsynced lyrics");
+	                  ?: deadbeef->pl_find_meta(track, "unsynced lyrics")
 	                  ?: deadbeef->pl_find_meta(track, "UNSYNCEDLYRICS");
 	if (lyrics)
 		return ustring{lyrics};


### PR DESCRIPTION
This edit also adds the kind of "Unsynced Lyrics" tag used in Ogg Vorbis music files.